### PR TITLE
Add room support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,27 @@ node_js:
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r-test
+    - ubuntu-toolchain-r-test
     packages:
-      - gcc-4.9
-      - g++-4.9
+    - gcc-4.9
+    - g++-4.9
 before_install:
 - export CC="gcc-4.9" CXX="g++-4.9"
 script:
 - npm test && cat ./coverage/lcov.info | ./node_modules/.bin/codecov
 notifications:
+  webhooks:
+    urls:
+    - https://webhooks.gitter.im/e/8e145155fbaaf37cffea
+    on_success: change
+    on_failure: always
+    on_start: never
   email: false
+deploy:
+  provider: npm
+  email: support@kuzzle.io
+  api_key:
+    secure: 1hOmpsbrxFW2N7ohG2NinYdr+Ie/REKvRnhCT6g8NCtbi1EuM+ArEHk9fpoQ7mCVpubMNJkeyc8lfd6qchzQhLF9RT7qpp+ymKootIQcpDTAQ1vtEp2k61/s74VdPNgij2fm8RKE5j5Zv5RAz49RY2Kk5jFPimf8hpkHXTskrR2Bc7p90cD/WJXJp4kLrjWrjOlCx2+ChxYVyLbZu22IVgrmB8PMDmPEUeYs93+k9S5a9eNIFSGhNvRnvBIlwlhuv22AQzI+zi6zoIIvzjNE3v2aafmCel+cZFhyesGqxk4TruUE6vVNx5t4r/5S/Nu2FzJFtGXwKRRJAgnD+LkW8yZNbHmNsvSZWn9SdjB7IKQ0GIBMxGxqx57+7VSR+cK/8yj8wLu+svfPl9GnBPRrDIBVUoUx2QyFAia2MRTqT4mL5yY3RT70qoa57lxh8KDCbd7mARamU3sLrwiyAJBXq/vN5wVdvHjzSpMxmw4w2wdVt63qjC1vR0AIaDEVNZbV/e+/ew21LkzE1mF8BkEN0VTfqrghehj5Qk/Gmon1mSVpesEDJIHKCJ1Y9PG8ReyxrQKXulgcKrR34nZoLkIJzV9NP2cbpY7WDRYOMYG9G7Sj5Of+thRrCguxBLtQuhbeILpc/MoL7gLAg0LOl5Q13xHZb6uPp+bFlW+aFPecOBo=
+  on:
+    repo: kuzzleio/kuzzle-plugin-websocket
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 language: node_js
 node_js:
 - 4.2
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.9
+      - g++-4.9
+before_install:
+- export CC="gcc-4.9" CXX="g++-4.9"
 script:
 - npm test && cat ./coverage/lcov.info | ./node_modules/.bin/codecov
 notifications:

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016 Kuzzle
+   Copyright 2015 Kaliop SAS
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -199,4 +199,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2015 Kaliop SAS
+   Copyright 2016 Kaliop SAS
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Protocol plugin adding websocket support to Kuzzle.
 
+Requires Kuzzle 1.0.0-RC5 or higher.
+
 # Manifest
 
 This plugin doesn't need any right.
@@ -16,7 +18,7 @@ You can override the configuration usign the CLI utilitie in Kuzzle:
 
 | Name | Default value | Type | Description                 |
 |------|---------------|-----------|-----------------------------|
-| ``port`` | ``5713`` | Integer > 1024 | Network port to open |
+| ``port`` | ``7513`` | Integer > 1024 | Network port to open |
 
 # How to use
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,22 @@ You can override the configuration usign the CLI utilitie in Kuzzle:
 |------|---------------|-----------|-----------------------------|
 | ``port`` | ``5713`` | Integer > 1024 | Network port to open |
 
+# How to use
+
+Kuzzle may send a multitude of messages to a client, either to respond to multiple asynchronous requests, or to notify events on client's subscriptions.  
+To allow a client to link a response to a request or to a subscription, Kuzzle normally features a room system for protocols allowing it.
+
+Since WebSocket messages do not support this feature natively, all messages sent through this protocol contain an additional `room` attribute at the root of the message structure. Clients connecting to Kuzzle using this protocol must use this field to dispatch incoming messages to the right parts of an application.
+
+This `room` attribute is either:
+
+* a request `requestId`, for request responses
+* a `channel` (see [Kuzzle subscriptions](http://kuzzle.io/api-reference/#on)), for notifications on subscriptions
+
+
 # How to create a plugin
 
-See [Kuzzle documentation](https://github.com/kuzzleio/kuzzle/blob/master/docs/plugins.md) about plugin for more information about how to create your own plugin.
+See [Kuzzle documentation](http://kuzzle.io/guide/#plugins) about plugin for more information about how to create your own plugin.
 
 # About Kuzzle
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 var
   WebSocketServer = require('ws').Server,
-  async = require('async'),
   uuid = require('node-uuid');
 
 /**
@@ -13,7 +12,6 @@ function WebsocketProtocol () {
   this.context = null;
   this.channels = {};
   this.connectionPool = {};
-  this.socketPool = {};
   this.server = {};
 
   this.init = function (config, context, isDummy) {
@@ -35,7 +33,7 @@ function WebsocketProtocol () {
       return this;
     }
 
-    this.server = new WebSocketServer({port: config.port});
+    this.server = new WebSocketServer({port: config.port}, {perMessageDeflate: false});
 
     this.server.on('connection', this.onConnection.bind(this));
     this.server.on('error', this.onServerError.bind(this));
@@ -50,11 +48,14 @@ function WebsocketProtocol () {
 
   this.onConnection = function (clientSocket) {
     var clientId = uuid.v4();
-    this.socketPool[clientId] = clientSocket;
 
     this.context.accessors.router.newConnection(this.protocol, clientId)
       .then(connection => {
-        this.connectionPool[clientId] = connection;
+        this.connectionPool[clientId] = {
+          connection,
+          socket: clientSocket,
+          channels: []
+        };
       });
 
     clientSocket.on('close', () => {
@@ -72,9 +73,9 @@ function WebsocketProtocol () {
 
   this.onClientDisconnection = function (clientId) {
     if (this.connectionPool[clientId]) {
-      this.context.accessors.router.removeConnection(this.connectionPool[clientId]);
+      this.context.accessors.router.removeConnection(this.connectionPool[clientId].connection);
+      this.connectionPool[clientId].channels.forEach(channel => this.leaveChannel({id: clientId, channel}));
       delete this.connectionPool[clientId];
-      delete this.socketPool[clientId];
     }
   };
 
@@ -83,21 +84,18 @@ function WebsocketProtocol () {
       requestObject,
       payload;
 
-    if (data) {
+    if (data && this.connectionPool[clientId]) {
       payload = JSON.parse(data);
+      requestObject = new this.context.constructors.RequestObject(payload, {}, this.protocol);
 
-      if (this.connectionPool[clientId]) {
-        requestObject = new this.context.constructors.RequestObject(payload, {}, this.protocol);
-
-        this.context.accessors.router.execute(
-          requestObject,
-          this.connectionPool[clientId],
-          (error, response) => {
-            response.room = response.requestId;
-            this.socketPool[clientId].send(JSON.stringify(response));
-          }
-        );
-      }
+      this.context.accessors.router.execute(
+        requestObject,
+        this.connectionPool[clientId].connection,
+        (error, response) => {
+          response.room = response.requestId;
+          this.connectionPool[clientId].socket.send(JSON.stringify(response));
+        }
+      );
     }
   };
 
@@ -111,11 +109,10 @@ function WebsocketProtocol () {
     if (this.channels[data.channel]) {
       payload = data.payload;
       payload.room = data.channel;
+      payload = JSON.stringify(payload);
 
-      this.channels[data.channel].forEach(clientId => {
-        if (this.connectionPool[clientId] && this.socketPool[clientId]) {
-          this.socketPool[clientId].send(JSON.stringify(payload));
-        }
+      Object.keys(this.channels[data.channel]).forEach(clientId => {
+        this.connectionPool[clientId].socket.send(payload);
       });
     }
   };
@@ -127,10 +124,10 @@ function WebsocketProtocol () {
       return false;
     }
 
-    if (this.connectionPool[data.id] && this.socketPool[data.id]) {
+    if (this.connectionPool[data.id]) {
       payload = data.payload;
       payload.room = data.channel;
-      this.socketPool[data.id].send(JSON.stringify(payload));
+      this.connectionPool[data.id].socket.send(JSON.stringify(payload));
     }
   };
 
@@ -141,10 +138,11 @@ function WebsocketProtocol () {
 
     if (this.connectionPool[data.id]) {
       if (!this.channels[data.channel]) {
-        this.channels[data.channel] = [];
+        this.channels[data.channel] = {};
       }
 
-      this.channels[data.channel].push(data.id);
+      this.channels[data.channel][data.id] = true;
+      this.connectionPool[data.id].channels.push(data.channel);
     }
   };
 
@@ -155,16 +153,18 @@ function WebsocketProtocol () {
       return false;
     }
 
-    if (this.connectionPool[data.id]) {
-      if (this.channels[data.channel]) {
-        index = this.channels[data.channel].indexOf(data.id);
-        if (index !== -1) {
-          this.channels[data.channel].splice(index, 1);
+    if (this.connectionPool[data.id] && this.channels[data.channel] && this.channels[data.channel][data.id]) {
+      if (Object.keys(this.channels[data.channel]).length > 1) {
+        delete this.channels[data.channel][data.id];
+      }
+      else {
+        delete this.channels[data.channel];
+      }
 
-          if (this.channels[data.channel].length === 0) {
-            delete this.channels[data.channel];
-          }
-        }
+      index = this.connectionPool[data.id].channels.indexOf(data.channel);
+
+      if (index !== -1) {
+        this.connectionPool[data.id].channels.splice(index, 1);
       }
     }
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,6 +52,7 @@ function WebsocketProtocol () {
     this.context.accessors.router.newConnection(this.protocol, clientId)
       .then(connection => {
         this.connectionPool[clientId] = {
+          alive: true,
           connection,
           socket: clientSocket,
           channels: []
@@ -73,8 +74,18 @@ function WebsocketProtocol () {
 
   this.onClientDisconnection = function (clientId) {
     if (this.connectionPool[clientId]) {
+      this.connectionPool[clientId].alive = false;
       this.context.accessors.router.removeConnection(this.connectionPool[clientId].connection);
-      this.connectionPool[clientId].channels.forEach(channel => this.leaveChannel({id: clientId, channel}));
+
+      this.connectionPool[clientId].channels.forEach(channel => {
+        if (this.channels[channel] && Object.keys(this.channels[channel]).length > 1) {
+          delete this.channels[channel][clientId];
+        }
+        else {
+          delete this.channels[channel];
+        }
+      });
+
       delete this.connectionPool[clientId];
     }
   };
@@ -95,7 +106,7 @@ function WebsocketProtocol () {
           response.room = response.requestId;
 
           // Connection may have been closed before sending this response
-          if (this.connectionPool[clientId] && this.connectionPool[clientId].socket) {
+          if (this.connectionPool[clientId] && this.connectionPool[clientId].alive) {
             this.connectionPool[clientId].socket.send(JSON.stringify(response));
           }
         }
@@ -116,7 +127,9 @@ function WebsocketProtocol () {
       payload = JSON.stringify(payload);
 
       Object.keys(this.channels[data.channel]).forEach(clientId => {
-        this.connectionPool[clientId].socket.send(payload);
+        if (this.connectionPool[clientId].alive) {
+          this.connectionPool[clientId].socket.send(payload);
+        }
       });
     }
   };
@@ -128,7 +141,7 @@ function WebsocketProtocol () {
       return false;
     }
 
-    if (this.connectionPool[data.id]) {
+    if (this.connectionPool[data.id] && this.connectionPool[data.id].alive) {
       payload = data.payload;
       payload.room = data.channel;
       this.connectionPool[data.id].socket.send(JSON.stringify(payload));
@@ -140,7 +153,7 @@ function WebsocketProtocol () {
       return false;
     }
 
-    if (this.connectionPool[data.id]) {
+    if (this.connectionPool[data.id] && this.connectionPool[data.id].alive) {
       if (!this.channels[data.channel]) {
         this.channels[data.channel] = {};
       }
@@ -157,7 +170,7 @@ function WebsocketProtocol () {
       return false;
     }
 
-    if (this.connectionPool[data.id] && this.channels[data.channel] && this.channels[data.channel][data.id]) {
+    if (this.connectionPool[data.id] && this.connectionPool[data.id].alive && this.channels[data.channel] && this.channels[data.channel][data.id]) {
       if (Object.keys(this.channels[data.channel]).length > 1) {
         delete this.channels[data.channel][data.id];
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ function WebsocketProtocol () {
   };
 
   this.onServerError = function (error) {
-    console.error('[plugin-websocket] A error has occured:', error);
+    console.error('[plugin-websocket] An error has occured:', error);
     this.isDummy = true;
   };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,8 +13,6 @@ function WebsocketProtocol () {
   this.channels = {};
   this.connectionPool = {};
   this.server = {};
-  this.sendBuffer = [];
-  this.concurrentSends = 10;
 
   this.init = function (config, context, isDummy) {
     if (!config) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 var
   WebSocketServer = require('ws').Server,
   uuid = require('node-uuid');
-
+//var Buffer = require('buffer');
 /**
  * @constructor
  */
@@ -113,22 +113,31 @@ function WebsocketProtocol () {
 
   this.broadcast = function (data) {
     var
-      pojoPayload,
       payload;
 
     if (this.isDummy) {
       return false;
     }
 
-    pojoPayload = data.payload;
+    /*
+     Avoids stringifying the payload multiple times just to update the room:
+      - we start deleting the last character, which is the closing JSON bracket ('}')
+      - we then only have to inject the following string to each channel:
+        ,"room":"<roomID"}
+
+      So, instead of stringifying the payload for each channel, we only concat
+      a new substring to the original payload.
+     */
+    payload = JSON.stringify(data.payload).slice(0, -1);
 
     data.channels.forEach(channel => {
+      var channelPayload;
+
       if (this.channels[channel]) {
-        pojoPayload.room = channel;
-        payload = JSON.stringify(pojoPayload);
+        channelPayload = payload + ',"room":"' + channel + '"}';
 
         Object.keys(this.channels[channel]).forEach(clientId => {
-          send(this.connectionPool, clientId, payload);
+          send(this.connectionPool, clientId, channelPayload);
         });
       }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,20 +115,22 @@ function WebsocketProtocol () {
 
   this.broadcast = function (data) {
     var
+      pojoPayload,
       payload;
 
     if (this.isDummy) {
       return false;
     }
 
-    payload = data.payload;
+    pojoPayload = data.payload;
 
     data.channels.forEach(channel => {
-      payload.room = channel;
-
       if (this.channels[channel]) {
+        pojoPayload.room = channel;
+        payload = JSON.stringify(pojoPayload);
+
         Object.keys(this.channels[channel]).forEach(clientId => {
-          send(this.connectionPool, clientId, JSON.stringify(payload));
+          send(this.connectionPool, clientId, payload);
         });
       }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,7 +93,11 @@ function WebsocketProtocol () {
         this.connectionPool[clientId].connection,
         (error, response) => {
           response.room = response.requestId;
-          this.connectionPool[clientId].socket.send(JSON.stringify(response));
+
+          // Connection may have been closed before sending this response
+          if (this.connectionPool[clientId] && this.connectionPool[clientId].socket) {
+            this.connectionPool[clientId].socket.send(JSON.stringify(response));
+          }
         }
       );
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 var
   WebSocketServer = require('ws').Server,
   uuid = require('node-uuid');
-//var Buffer = require('buffer');
+
 /**
  * @constructor
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,7 +112,7 @@ function WebsocketProtocol () {
       payload = data.payload;
       payload.room = data.channel;
 
-      async.each(this.channels[data.channel], (clientId) => {
+      this.channels[data.channel].forEach(clientId => {
         if (this.connectionPool[clientId] && this.socketPool[clientId]) {
           this.socketPool[clientId].send(JSON.stringify(payload));
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,14 +17,13 @@ function WebsocketProtocol () {
   this.server = {};
 
   this.init = function (config, context, isDummy) {
-
     if (!config) {
-      throw new Error('plugin-websocket: A configuration parameter is required');
+      throw new Error('[plugin-websocket] A configuration parameter is required');
     }
 
     if (!config.port) {
       this.isDummy = true;
-      console.error(new Error('plugin-websocket: the \'port\' attribute, with the port to listen to, is required'));
+      console.error(new Error('[plugin-websocket] The \'port\' attribute, with the port to listen to, is required'));
       return false;
     }
 
@@ -45,7 +44,7 @@ function WebsocketProtocol () {
   };
 
   this.onServerError = function (error) {
-    console.error('An error has occured:', error);
+    console.error('[plugin-websocket] A error has occured:', error);
     this.isDummy = true;
   };
 
@@ -94,6 +93,7 @@ function WebsocketProtocol () {
           requestObject,
           this.connectionPool[clientId],
           (error, response) => {
+            response.room = response.requestId;
             this.socketPool[clientId].send(JSON.stringify(response));
           }
         );
@@ -102,26 +102,35 @@ function WebsocketProtocol () {
   };
 
   this.broadcast = function (data) {
+    var payload;
+
     if (this.isDummy) {
       return false;
     }
 
     if (this.channels[data.channel]) {
+      payload = data.payload;
+      payload.room = data.channel;
+
       async.each(this.channels[data.channel], (clientId) => {
         if (this.connectionPool[clientId] && this.socketPool[clientId]) {
-          this.socketPool[clientId].send(JSON.stringify(data.payload));
+          this.socketPool[clientId].send(JSON.stringify(payload));
         }
       });
     }
   };
 
   this.notify = function (data) {
+    var payload;
+
     if (this.isDummy) {
       return false;
     }
 
     if (this.connectionPool[data.id] && this.socketPool[data.id]) {
-      this.socketPool[data.id].send(JSON.stringify(data.payload));
+      payload = data.payload;
+      payload.room = data.channel;
+      this.socketPool[data.id].send(JSON.stringify(payload));
     }
   };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,8 @@ function WebsocketProtocol () {
   this.channels = {};
   this.connectionPool = {};
   this.server = {};
+  this.sendBuffer = [];
+  this.concurrentSends = 10;
 
   this.init = function (config, context, isDummy) {
     if (!config) {
@@ -78,8 +80,9 @@ function WebsocketProtocol () {
       this.context.accessors.router.removeConnection(this.connectionPool[clientId].connection);
 
       this.connectionPool[clientId].channels.forEach(channel => {
-        if (this.channels[channel] && Object.keys(this.channels[channel]).length > 1) {
+        if (this.channels[channel] && this.channels[channel].count > 1) {
           delete this.channels[channel][clientId];
+          this.channels[channel].count--;
         }
         else {
           delete this.channels[channel];
@@ -104,34 +107,31 @@ function WebsocketProtocol () {
         this.connectionPool[clientId].connection,
         (error, response) => {
           response.room = response.requestId;
-
-          // Connection may have been closed before sending this response
-          if (this.connectionPool[clientId] && this.connectionPool[clientId].alive) {
-            this.connectionPool[clientId].socket.send(JSON.stringify(response));
-          }
+          send(this.connectionPool, clientId, JSON.stringify(response));
         }
       );
     }
   };
 
   this.broadcast = function (data) {
-    var payload;
+    var
+      payload;
 
     if (this.isDummy) {
       return false;
     }
 
-    if (this.channels[data.channel]) {
-      payload = data.payload;
-      payload.room = data.channel;
-      payload = JSON.stringify(payload);
+    payload = data.payload;
 
-      Object.keys(this.channels[data.channel]).forEach(clientId => {
-        if (this.connectionPool[clientId].alive) {
-          this.connectionPool[clientId].socket.send(payload);
-        }
-      });
-    }
+    data.channels.forEach(channel => {
+      payload.room = channel;
+
+      if (this.channels[channel]) {
+        Object.keys(this.channels[channel]).forEach(clientId => {
+          send(this.connectionPool, clientId, JSON.stringify(payload));
+        });
+      }
+    });
   };
 
   this.notify = function (data) {
@@ -141,11 +141,12 @@ function WebsocketProtocol () {
       return false;
     }
 
-    if (this.connectionPool[data.id] && this.connectionPool[data.id].alive) {
-      payload = data.payload;
-      payload.room = data.channel;
-      this.connectionPool[data.id].socket.send(JSON.stringify(payload));
-    }
+    payload = data.payload;
+
+    data.channels.forEach(channel => {
+      payload.room = channel;
+      send(this.connectionPool, data.id, JSON.stringify(payload));
+    });
   };
 
   this.joinChannel = function (data) {
@@ -155,10 +156,13 @@ function WebsocketProtocol () {
 
     if (this.connectionPool[data.id] && this.connectionPool[data.id].alive) {
       if (!this.channels[data.channel]) {
-        this.channels[data.channel] = {};
+        this.channels[data.channel] = {
+          count: 0
+        };
       }
 
       this.channels[data.channel][data.id] = true;
+      this.channels[data.channel].count++;
       this.connectionPool[data.id].channels.push(data.channel);
     }
   };
@@ -171,8 +175,9 @@ function WebsocketProtocol () {
     }
 
     if (this.connectionPool[data.id] && this.connectionPool[data.id].alive && this.channels[data.channel] && this.channels[data.channel][data.id]) {
-      if (Object.keys(this.channels[data.channel]).length > 1) {
+      if (this.channels[data.channel].count > 1) {
         delete this.channels[data.channel][data.id];
+        this.channels[data.channel].count--;
       }
       else {
         delete this.channels[data.channel];
@@ -185,6 +190,12 @@ function WebsocketProtocol () {
       }
     }
   };
+}
+
+function send(pool, id, data) {
+  if (pool[id] && pool[id].alive && pool[id].socket.readyState === pool[id].socket.OPEN) {
+    pool[id].socket.send(data);
+  }
 }
 
 module.exports = WebsocketProtocol;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "url": "git+https://github.com/kuzzleio/kuzzle-plugin-websocket.git"
   },
   "scripts": {
-    "test": "istanbul cover _mocha"
+    "lint": "eslint lib/*.js test/*.js",
+    "unit-tests": "istanbul cover _mocha",
+    "test": "npm run-script lint && npm run-script unit-tests"
   },
   "keywords": [
     "kuzzle",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "bufferutil": "^1.2.1",
     "node-uuid": "^1.4.7",
+    "utf-8-validate": "^1.2.1",
     "ws": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
   },
   "pluginInfo": {
     "defaultConfig": {
-      "loadBalancerUrl": "ws://loadbalancer:7331",
-      "retryInterval": 1000,
-      "loadedBy": "server"
+      "port": 5713
     }
   },
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-websocket",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Protocol plugin adding Websocket support to Kuzzle",
   "main": "./lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "pluginInfo": {
     "defaultConfig": {
-      "port": 5713
+      "port": 7513
     }
   },
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "async": "^2.0.0-rc.5",
     "node-uuid": "^1.4.7",
     "ws": "^1.1.1"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -81,7 +81,7 @@ describe('plugin implementation', function () {
       should(setBackend).be.null();
     });
 
-    it('should setup a mosca mqtt broker if not in dummy mode', function () {
+    it('should setup a websocket server if not in dummy mode', function () {
       var ret = plugin.init(config, context, false);
 
       should(ret).be.eql(plugin);
@@ -174,7 +174,8 @@ describe('plugin implementation', function () {
         [goodChannel]: [goodId]
       };
       plugin.broadcast({
-        channel: goodChannel
+        channel: goodChannel,
+        payload: {}
       });
       should(sendSpy.callCount).be.eql(0);
     });
@@ -194,10 +195,10 @@ describe('plugin implementation', function () {
       };
       plugin.broadcast({
         channel: goodChannel,
-        payload: 'aPayload'
+        payload: {some: 'data'}
       });
       should(sendSpy.callCount).be.eql(1);
-      should(sendSpy.firstCall.args[0]).be.eql(JSON.stringify('aPayload'));
+      should(sendSpy.firstCall.args[0]).be.eql(JSON.stringify({some: 'data', room: goodChannel}));
     });
   });
 
@@ -231,10 +232,11 @@ describe('plugin implementation', function () {
       };
       plugin.notify({
         id: goodId,
-        payload: 'aPayload'
+        channel: goodChannel,
+        payload: {some: 'data'}
       });
       should(sendSpy.callCount).be.eql(1);
-      should(sendSpy.firstCall.args[0]).be.eql(JSON.stringify('aPayload'));
+      should(sendSpy.firstCall.args[0]).be.eql(JSON.stringify({some: 'data', room: goodChannel}));
     });
   });
 
@@ -372,7 +374,7 @@ describe('plugin implementation', function () {
       config = {port: 1234},
       fakeRequestObject = {aRequest: 'Object'},
       requestObjectStub = sinon.stub().returns(fakeRequestObject),
-      executeStub = sinon.stub().callsArg(2),
+      executeStub = sinon.stub().callsArgWith(2, null, {requestId: 'foo'}),
       context = {constructors: {RequestObject: requestObjectStub}, accessors: {router: {execute: executeStub}}};
 
     beforeEach(() => {
@@ -418,7 +420,7 @@ describe('plugin implementation', function () {
       should(executeStub.firstCall.args[1]).be.eql('aConnection');
       should(executeStub.firstCall.args[2]).be.Function();
       should(sendSpy.callCount).be.eql(1);
-      should(sendSpy.firstCall.args[0]).be.eql(JSON.stringify(undefined));
+      should(sendSpy.firstCall.args[0]).be.eql(JSON.stringify({requestId: 'foo', room: 'foo'}));
     });
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -178,6 +178,7 @@ describe('plugin implementation', function () {
       };
       plugin.connectionPool = {
         [goodId]: {
+          alive: true,
           socket: {
             send: sendSpy
           }
@@ -215,6 +216,7 @@ describe('plugin implementation', function () {
       plugin.init(config, context, false);
       plugin.connectionPool = {
         [goodId]: {
+          alive: true,
           socket: {
             send: sendSpy
           }
@@ -256,6 +258,7 @@ describe('plugin implementation', function () {
       };
       plugin.connectionPool = {
         [goodId]: {
+          alive: true,
           socket: {
             send: sendSpy
           },
@@ -275,6 +278,7 @@ describe('plugin implementation', function () {
       plugin.init(config, context, false);
       plugin.connectionPool = {
         [goodId]: {
+          alive: true,
           socket: {
             send: sendSpy
           },
@@ -312,7 +316,9 @@ describe('plugin implementation', function () {
     it('should do nothing if channel does not exist', function () {
       plugin.init(config, context, false);
       plugin.connectionPool = {
-        [goodId]: true
+        [goodId]:  {
+          alive: true
+        }
       };
       plugin.leaveChannel({
         id: goodId
@@ -324,6 +330,7 @@ describe('plugin implementation', function () {
       plugin.init(config, context, false);
       plugin.connectionPool = {
         [goodId]: {
+          alive: true,
           socket: {
             send: sendSpy
           },
@@ -346,6 +353,7 @@ describe('plugin implementation', function () {
       plugin.init(config, context, false);
       plugin.connectionPool = {
         [goodId]: {
+          alive: true,
           socket: {
             send: sendSpy
           },
@@ -370,6 +378,7 @@ describe('plugin implementation', function () {
       plugin.init(config, context, false);
       plugin.connectionPool = {
         [goodId]: {
+          alive: true,
           socket: {
             send: sendSpy
           },
@@ -403,7 +412,9 @@ describe('plugin implementation', function () {
     it('should do nothing if the data is undefined', function () {
       plugin.init(config, context, false);
       plugin.connectionPool = {
-        [goodId]: true
+        [goodId]: {
+          alive: true
+        }
       };
       plugin.onClientMessage(badId, undefined);
       should(executeStub.callCount).be.eql(0);
@@ -413,7 +424,9 @@ describe('plugin implementation', function () {
     it('should do nothing if the client is unknown', function () {
       plugin.init(config, context, false);
       plugin.connectionPool = {
-        [goodId]: true
+        [goodId]: {
+          alive: true
+        }
       };
       plugin.onClientMessage(badId, JSON.stringify('aPayload'));
       should(executeStub.callCount).be.eql(0);
@@ -424,6 +437,7 @@ describe('plugin implementation', function () {
       plugin.init(config, context, false);
       plugin.connectionPool = {
         [goodId]: {
+          alive: true,
           connection: 'aConnection',
           socket: {
             send: sendSpy
@@ -473,26 +487,27 @@ describe('plugin implementation', function () {
         [goodChannel]: []
       };
       plugin.connectionPool = {
-        [goodId]: true
+        [goodId]: {
+          alive: true
+        }
       };
       plugin.socketPool = {
         [goodId]: true
       };
       plugin.onClientDisconnection(badId);
       should(removeConnectionSpy.callCount).be.eql(0);
-      should(plugin.connectionPool[goodId]).be.true();
+      should(plugin.connectionPool[goodId].alive).be.true();
       should(plugin.socketPool[goodId]).be.true();
     });
 
     it('should remove the client connection if it exists', function () {
-      var stub = sinon.stub(plugin, 'leaveChannel');
-
       plugin.init(config, context, false);
       plugin.channels = {
-        [goodChannel]: {[goodId]: true}
+        [goodChannel]: {[goodId]: true, 'foobar': true}
       };
       plugin.connectionPool = {
         [goodId]: {
+          alive: true,
           connection: 'aConnection',
           socket: {
             send: sendSpy
@@ -504,9 +519,29 @@ describe('plugin implementation', function () {
       plugin.onClientDisconnection(goodId);
       should(removeConnectionSpy.callCount).be.eql(1);
       should(plugin.connectionPool).be.deepEqual({});
-      should(stub.calledOnce).be.true();
-      should(stub.calledWith({id: goodId, channel: goodChannel}));
-      stub.reset();
+      should(plugin.channels).be.deepEqual({[goodChannel]: {foobar: true}});
+    });
+
+    it('should remove a channel entirely if the last connection leaves', function () {
+      plugin.init(config, context, false);
+      plugin.channels = {
+        [goodChannel]: {[goodId]: true}
+      };
+      plugin.connectionPool = {
+        [goodId]: {
+          alive: true,
+          connection: 'aConnection',
+          socket: {
+            send: sendSpy
+          },
+          channels: [goodChannel]
+        }
+      };
+
+      plugin.onClientDisconnection(goodId);
+      should(removeConnectionSpy.callCount).be.eql(1);
+      should(plugin.connectionPool).be.deepEqual({});
+      should(plugin.channels).be.deepEqual({});
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -174,7 +174,8 @@ describe('plugin implementation', function () {
         [goodChannel]: [goodId]
       };
       plugin.broadcast({
-        channel: goodChannel
+        channel: goodChannel,
+        payload: {}
       });
       should(sendSpy.callCount).be.eql(0);
     });
@@ -194,10 +195,10 @@ describe('plugin implementation', function () {
       };
       plugin.broadcast({
         channel: goodChannel,
-        payload: 'aPayload'
+        payload: {some: 'data'}
       });
       should(sendSpy.callCount).be.eql(1);
-      should(sendSpy.firstCall.args[0]).be.eql(JSON.stringify('aPayload'));
+      should(sendSpy.firstCall.args[0]).be.eql(JSON.stringify({some: 'data', room: goodChannel}));
     });
   });
 
@@ -231,10 +232,11 @@ describe('plugin implementation', function () {
       };
       plugin.notify({
         id: goodId,
-        payload: 'aPayload'
+        channel: goodChannel,
+        payload: {some: 'data'}
       });
       should(sendSpy.callCount).be.eql(1);
-      should(sendSpy.firstCall.args[0]).be.eql(JSON.stringify('aPayload'));
+      should(sendSpy.firstCall.args[0]).be.eql(JSON.stringify({some: 'data', room: goodChannel}));
     });
   });
 
@@ -372,7 +374,7 @@ describe('plugin implementation', function () {
       config = {port: 1234},
       fakeRequestObject = {aRequest: 'Object'},
       requestObjectStub = sinon.stub().returns(fakeRequestObject),
-      executeStub = sinon.stub().callsArg(2),
+      executeStub = sinon.stub().callsArgWith(2, null, {requestId: 'foo'}),
       context = {constructors: {RequestObject: requestObjectStub}, accessors: {router: {execute: executeStub}}};
 
     beforeEach(() => {
@@ -418,7 +420,7 @@ describe('plugin implementation', function () {
       should(executeStub.firstCall.args[1]).be.eql('aConnection');
       should(executeStub.firstCall.args[2]).be.Function();
       should(sendSpy.callCount).be.eql(1);
-      should(sendSpy.firstCall.args[0]).be.eql(JSON.stringify(undefined));
+      should(sendSpy.firstCall.args[0]).be.eql(JSON.stringify({requestId: 'foo', room: 'foo'}));
     });
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -163,7 +163,8 @@ describe('plugin implementation', function () {
     it('should do nothing if channel does not exist', function () {
       plugin.init(config, context, false);
       plugin.broadcast({
-        channel: badChannel
+        channels: [badChannel],
+        payload: {}
       });
       should(sendSpy.callCount).be.eql(0);
     });
@@ -186,7 +187,7 @@ describe('plugin implementation', function () {
       };
 
       plugin.broadcast({
-        channel: goodChannel,
+        channels: [goodChannel],
         payload: {some: 'data'}
       });
       should(sendSpy.callCount).be.eql(1);
@@ -207,7 +208,9 @@ describe('plugin implementation', function () {
     it('should do nothing if id does not exist', function () {
       plugin.init(config, context, false);
       plugin.notify({
-        id: badId
+        id: badId,
+        payload: {},
+        channels: [goodChannel]
       });
       should(sendSpy.callCount).be.eql(0);
     });
@@ -225,7 +228,7 @@ describe('plugin implementation', function () {
 
       plugin.notify({
         id: goodId,
-        channel: goodChannel,
+        channels: [goodChannel],
         payload: {some: 'data'}
       });
       should(sendSpy.callCount).be.eql(1);
@@ -254,7 +257,7 @@ describe('plugin implementation', function () {
     it('should add clientId to the channel if conditions are met', function () {
       plugin.init(config, context, false);
       plugin.channels = {
-        [goodChannel]: {}
+        [goodChannel]: { count: 0 }
       };
       plugin.connectionPool = {
         [goodId]: {
@@ -270,7 +273,7 @@ describe('plugin implementation', function () {
         channel: goodChannel
       });
       should(plugin.channels).be.deepEqual({
-        [goodChannel]: { [goodId]: true }
+        [goodChannel]: { [goodId]: true, count: 1 }
       });
     });
 
@@ -290,7 +293,7 @@ describe('plugin implementation', function () {
         channel: goodChannel
       });
       should(plugin.channels).be.deepEqual({
-        [goodChannel]: { [goodId]: true }
+        [goodChannel]: { [goodId]: true, count: 1 }
       });
     });
   });
@@ -361,7 +364,7 @@ describe('plugin implementation', function () {
         }
       };
       plugin.channels = {
-        [goodChannel]: {[goodId]: true, [badId]: true}
+        [goodChannel]: {[goodId]: true, [badId]: true, count: 2}
       };
       plugin.leaveChannel({
         id: goodId,
@@ -369,7 +372,7 @@ describe('plugin implementation', function () {
       });
 
       should(plugin.channels).be.deepEqual({
-        [goodChannel]: {[badId]: true}
+        [goodChannel]: {[badId]: true, count: 1}
       });
       should(plugin.connectionPool[goodId].channels.length).be.eql(0);
     });
@@ -503,7 +506,7 @@ describe('plugin implementation', function () {
     it('should remove the client connection if it exists', function () {
       plugin.init(config, context, false);
       plugin.channels = {
-        [goodChannel]: {[goodId]: true, 'foobar': true}
+        [goodChannel]: {[goodId]: true, 'foobar': true, count: 2}
       };
       plugin.connectionPool = {
         [goodId]: {
@@ -519,7 +522,7 @@ describe('plugin implementation', function () {
       plugin.onClientDisconnection(goodId);
       should(removeConnectionSpy.callCount).be.eql(1);
       should(plugin.connectionPool).be.deepEqual({});
-      should(plugin.channels).be.deepEqual({[goodChannel]: {foobar: true}});
+      should(plugin.channels).be.deepEqual({[goodChannel]: {foobar: true, count: 1}});
     });
 
     it('should remove a channel entirely if the last connection leaves', function () {


### PR DESCRIPTION

Until now, implemented protocols in Kuzzle are able to dispatch messages to specific rooms, allowing client to listen to specific messages (AMQP, Socket.IO, MQTT, etc).

This is not the case with pure WebSockets, as this protocol do not feature such a functionality.

The purpose of this PR is to systematically add a `room` attribute to messages, allowing clients to dispatch incoming payloads themselves.

# Changelog

* add a `room` attribute to all outgoing messages
* update README file with a new `How to use` paragraph, explaining how to properly dispatch messages client-side
* update unit tests to check that the `room` attribute is correctly added
* heavy performances improvements
* bugfix: a connection close event now properly remove associated channels
* added eslint to "npm test" runs

